### PR TITLE
Fix for reading generic data records.

### DIFF
--- a/data_file.go
+++ b/data_file.go
@@ -128,19 +128,19 @@ func (this *DataFileReader) hasNextBlock() bool {
 	return int64(len(this.data)) > this.dec.Tell()
 }
 
-func (this *DataFileReader) Next(v interface{}) (bool, error) {
+func (this *DataFileReader) Next(v interface{}) (interface{}, error) {
 	if hasNext, err := this.hasNext(); err != nil {
-		return false, err
+		return nil, err
 	} else {
 		if hasNext {
-			_, err := this.datum.Read(v, this.blockDecoder)
+			rdata, err := this.datum.Read(v, this.blockDecoder)
 			if err != nil {
-				return false, err
+				return nil, err
 			}
 			this.block.BlockRemaining--
-			return true, nil
+			return rdata, nil
 		} else {
-			return false, nil
+			return nil, nil
 		}
 	}
 	return false, nil

--- a/datum_reader.go
+++ b/datum_reader.go
@@ -237,7 +237,7 @@ func (this *SpecificDatumReader) mapRecord(field Schema, reflectField reflect.Va
 }
 
 type GenericDatumReader struct {
-	schema Schema
+	Schema Schema
 }
 
 func NewGenericDatumReader() *GenericDatumReader {
@@ -245,15 +245,15 @@ func NewGenericDatumReader() *GenericDatumReader {
 }
 
 func (this *GenericDatumReader) SetSchema(schema Schema) {
-	this.schema = schema
+	this.Schema = schema
 }
 
 func (this *GenericDatumReader) Read(v interface{}, dec Decoder) (interface{}, error) {
-	if this.schema == nil {
+	if this.Schema == nil {
 		return nil, SchemaNotSet
 	}
 
-	return this.readValue(this.schema, dec)
+	return this.readValue(this.Schema, dec)
 }
 
 func (this *GenericDatumReader) findAndSet(record *GenericRecord, field *SchemaField, dec Decoder) error {


### PR DESCRIPTION
The API for specific records and generic records were not
copatible, causing to generic data to simply be dropped.
This commit returns the generic data, while ignoring the
record passed in. Reading specific record continues to
populate the passed record.

This solves the immediate issue or dropping data. The API
is bit more clounky though.