### PR TITLE
Add MustParseSchema function

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -432,6 +432,16 @@ func ParseSchema(rawSchema string) (Schema, error) {
 	return schemaByType(schema)
 }
 
+// MustParseSchema is like ParseSchema, but panics if the given schema
+// cannot be parsed.
+func MustParseSchema(rawSchema string) Schema {
+	s, err := ParseSchema(rawSchema)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
 func schemaByType(i interface{}) (Schema, error) {
 	switch v := i.(type) {
 	case nil:


### PR DESCRIPTION
I found myself creating an app-global schema. I want to parse it once. A failure to parse is such a critical error that we should just panic immediately.