### PR TITLE
Protocol Parser

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,26 @@
+
+package avro
+
+import (
+	"encoding/json"
+	//"fmt"
+)
+
+type Protocol struct {
+	records map[string]Schema
+}
+
+
+func ParseProtocol(rawProtocol string) (Protocol, error) {
+	var protocol map[string]interface{}
+	if err := json.Unmarshal([]byte(rawProtocol), &protocol); err != nil {
+		return Protocol{}, err
+	}
+	schemas := make(map[string]Schema)
+	out := make(map[string]Schema)
+	for _, schema := range protocol["types"].([]interface{}) {
+		a, _ := schemaByType(schema, schemas, "")
+		out[a.GetName()] = a
+	}
+	return Protocol{records:out}, nil
+}

--- a/schema.go
+++ b/schema.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math"
 	"reflect"
+	"strings"
 )
 
 const (
@@ -978,7 +979,8 @@ func parseEnumSchema(v map[string]interface{}, registry map[string]Schema, names
 	setOptionalField(&schema.Namespace, v, schema_namespaceField)
 	setOptionalField(&schema.Doc, v, schema_docField)
 	schema.Properties = getProperties(v)
-
+	//Fix characters in docs that can mess with code generation
+	schema.Doc = strings.Replace(schema.Doc, "`", "'", -1)
 	return addSchema(getFullName(v[schema_nameField].(string), namespace), schema, registry)
 }
 
@@ -1018,7 +1020,8 @@ func parseRecordSchema(v map[string]interface{}, registry map[string]Schema, nam
 	}
 	schema.Fields = fields
 	schema.Properties = getProperties(v)
-
+  //Fix characters in docs that can mess with code generation
+	schema.Doc = strings.Replace(schema.Doc, "`", "'", -1)
 	return schema, nil
 }
 
@@ -1027,6 +1030,9 @@ func parseSchemaField(i interface{}, registry map[string]Schema, namespace strin
 	case map[string]interface{}:
 		schemaField := &SchemaField{Name: v[schema_nameField].(string)}
 		setOptionalField(&schemaField.Doc, v, schema_docField)
+		//Fix characters in docs that can mess with code generation
+		schemaField.Doc = strings.Replace(schemaField.Doc, "`", "'", -1)
+
 		fieldType, err := schemaByType(v[schema_typeField], registry, namespace)
 		if err != nil {
 			return nil, err

--- a/schema.go
+++ b/schema.go
@@ -879,7 +879,6 @@ func ParseSchemaWithRegistry(rawSchema string, schemas map[string]Schema) (Schem
 	if err := json.Unmarshal([]byte(rawSchema), &schema); err != nil {
 		schema = rawSchema
 	}
-
 	return schemaByType(schema, schemas, "")
 }
 


### PR DESCRIPTION
This is a first pass at parsing AVRO protocol files (avpr). It doesn't yet do anything with messages, but it will parse out the array of defines record schemas. The '--protocol' flag can now be passed to the codegen tool to use it.