### PR TITLE
Optimize findField operation heavily using a type map

### DIFF
--- a/datum_reader_test.go
+++ b/datum_reader_test.go
@@ -1,6 +1,7 @@
 package avro
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -265,4 +266,60 @@ func TestComplexOfComplexBinding(t *testing.T) {
 			}
 		}
 	}
+}
+
+func BenchmarkSpecificDatumReader_complex(b *testing.B) {
+	var dest complex
+	specificReaderBenchComplex(b, &dest)
+}
+
+func BenchmarkSpecificDatumReader_hugeval(b *testing.B) {
+	var dest struct {
+		complex
+		primitive
+		testRecord
+	}
+	specificReaderBenchComplex(b, &dest)
+}
+
+func specificReaderComplexVal() (Schema, []byte) {
+	schema, err := ParseSchemaFile("test/schemas/test_record.avsc")
+	if err != nil {
+		panic(err)
+	}
+	e := NewGenericEnum([]string{"A", "B", "C", "D"})
+	e.Set("A")
+	c := newComplex()
+	c.EnumField.Set("A")
+	c.FixedField = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	buf := testEncodeBytes(schema, c)
+	return schema, buf
+}
+
+func specificReaderBenchComplex(b *testing.B, dest interface{}) {
+	schema, buf := specificReaderComplexVal()
+	datumReader := NewSpecificDatumReader()
+	datumReader.SetSchema(schema)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dec := NewBinaryDecoder(buf)
+		err := datumReader.Read(dest, dec)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func testEncodeBytes(schema Schema, rec interface{}) []byte {
+	var buf bytes.Buffer
+	w := NewSpecificDatumWriter()
+	w.SetSchema(schema)
+	encoder := NewBinaryEncoder(&buf)
+	err := w.Write(rec, encoder)
+	if err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
 }

--- a/datum_utils.go
+++ b/datum_utils.go
@@ -21,35 +21,50 @@ import (
 	"strings"
 )
 
-func fieldByTag(where reflect.Value, name string) reflect.Value {
-	elemType := where.Type()
-
-	for i := 0; i < where.NumField(); i++ {
-		field := where.Field(i)
-		if elemType.Field(i).Tag.Get("avro") == name {
-			return field
-		}
-	}
-
-	return reflect.Value{}
-}
-
 func findField(where reflect.Value, name string) (reflect.Value, error) {
 	if where.Kind() == reflect.Ptr {
 		where = where.Elem()
 	}
+	t := where.Type()
+	rm := reflectMap[t]
+	if rm == nil {
+		rm = reflectBuildRi(t)
+	}
+	if rf, ok := rm.names[name]; ok {
+		return where.FieldByIndex(rf), nil
+	}
+	return reflect.Value{}, fmt.Errorf("Field %s does not exist in %s", name, t.Name())
+}
 
-	field := fieldByTag(where, name)
-	if !field.IsValid() {
-		field = where.FieldByName(strings.ToUpper(name[0:1]) + name[1:])
-		if !field.IsValid() {
-			field = where.FieldByName(name)
+func reflectBuildRi(t reflect.Type) *reflectInfo {
+	rm := &reflectInfo{
+		names: make(map[string][]int),
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if strings.ToLower(f.Name[:1]) != f.Name[:1] {
+			tag := f.Tag.Get("avro")
+			if tag != "" {
+				rm.names[tag] = f.Index
+			} else {
+				rm.names[f.Name] = f.Index
+				rm.names[strings.ToLower(f.Name[:1])+f.Name[1:]] = f.Index
+			}
 		}
 	}
 
-	if !field.IsValid() {
-		return reflect.Value{}, fmt.Errorf("Field %s does not exist", name)
+	// copy the map instead of dealing with locking
+	m := make(map[reflect.Type]*reflectInfo, len(reflectMap)+1)
+	for k, v := range reflectMap {
+		m[k] = v
 	}
+	m[t] = rm
+	reflectMap = m
+	return rm
+}
 
-	return field, nil
+var reflectMap map[reflect.Type]*reflectInfo
+
+type reflectInfo struct {
+	names map[string][]int
 }


### PR DESCRIPTION
The existing findField operation was called for every element in the
schema; and iterated every field in the struct; effectively it does
m*n operations where m and n are typically close in number; or in
other words O(n^2).

Optimize findField by caching the field information the first time we
see a new reflect.Type. Not only does this make the operation run in
O(n) time, there's less string comparisons too now.


I made a [benchmark branch](https://github.com/crast/go-avro/tree/benchmark-cached-findfield) where I [left both functions side-by-side](https://github.com/crast/go-avro/blob/benchmark-cached-findfield/datum_utils.go#L37-L73) and swapped them out for each other so that I could [test various permutations](https://github.com/crast/go-avro/blob/benchmark-cached-findfield/datum_reader_test.go#L271-L299) and the growth rate.

The results were as follows (note this is benchmarking an entire SpecificDatumReader.Read, not the findField operation itself, just to show how much findField was overwhelming the decoder time):
```
BenchmarkSpecificDatumReader_complex_orig-4           100000         12266 ns/op
BenchmarkSpecificDatumReader_complex_newFindField-4   500000          3865 ns/op
BenchmarkSpecificDatumReader_hugeval_orig-4            50000         23620 ns/op
BenchmarkSpecificDatumReader_hugeval_newFindField-4   500000          3736 ns/op
```

Something to note - even though `hugeval` is a much bigger struct than `complex`, the `newFindField` variant ran in roughly the same time as 'complex'; because the time is now linear to the size of the schema, not really much related to the size of the target struct.

Also, I was able to confirm in another test where I added fields one at a time that the growth is indeed exponential on the original function. Even with small structs; this results in around a 4x speedup.

This is actually only step 1 of optimizations I would like to do; storing the interpretation of a struct paves the way for:

* Optimize the SpecificDatumReader to use a specific execution plan based on the schema and struct type.
* Set up a similar concept for the SpecificDatumWriter
* (maybe, far future) code-gen optimized readers