### PR TITLE
Do some speedups for varint encoding

### DIFF
--- a/datum_writer_test.go
+++ b/datum_writer_test.go
@@ -196,6 +196,39 @@ func randomPrimitiveObject() *primitive {
 	return p
 }
 
+func BenchmarkEncodeVarint32(b *testing.B) {
+	enc := NewBinaryEncoder(nil)
+	for i := 0; i < b.N; i++ {
+		enc.encodeVarint32(int32(i))
+	}
+}
+
+func BenchmarkEncodeVarint64(b *testing.B) {
+	enc := NewBinaryEncoder(nil)
+	for i := 0; i < b.N; i++ {
+		enc.encodeVarint64(int64(i))
+	}
+}
+
+func BenchmarkSpecificDatumWriter(b *testing.B) {
+	var c = newComplex()
+	c.FixedField = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	w := NewSpecificDatumWriter()
+	w.SetSchema(c.Schema())
+	var buf bytes.Buffer
+	buf.Grow(10000)
+	err := w.Write(c, NewBinaryEncoder(&buf))
+	if err != nil {
+		panic(err)
+	}
+	buf.Reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.Write(c, NewBinaryEncoder(&buf))
+		buf.Reset()
+	}
+}
+
 type _complex struct {
 	StringArray []string
 	LongArray   []int64

--- a/encoder.go
+++ b/encoder.go
@@ -85,12 +85,12 @@ func (this *BinaryEncoder) WriteBoolean(x bool) {
 
 // Writes an int value.
 func (this *BinaryEncoder) WriteInt(x int32) {
-	this.buffer.Write(this.encodeVarint(int64(x)))
+	this.buffer.Write(this.encodeVarint32(x))
 }
 
 // Writes a long value.
 func (this *BinaryEncoder) WriteLong(x int64) {
-	this.buffer.Write(this.encodeVarint(x))
+	this.buffer.Write(this.encodeVarint64(x))
 }
 
 // Writes a float value.
@@ -152,8 +152,25 @@ func (this *BinaryEncoder) writeItemCount(count int64) {
 	this.WriteLong(count)
 }
 
-func (this *BinaryEncoder) encodeVarint(x int64) []byte {
-	var buf = make([]byte, 10)
+func (this *BinaryEncoder) encodeVarint32(n int32) []byte {
+	var buf [5]byte
+	ux := uint32(n) << 1
+	if n < 0 {
+		ux = ^ux
+	}
+	i := 0
+	for ux >= 0x80 {
+		buf[i] = byte(ux) | 0x80
+		ux >>= 7
+		i++
+	}
+	buf[i] = byte(ux)
+
+	return buf[0 : i+1]
+}
+
+func (this *BinaryEncoder) encodeVarint64(x int64) []byte {
+	var buf [10]byte
 	ux := uint64(x) << 1
 	if x < 0 {
 		ux = ^ux


### PR DESCRIPTION
The primary change is using a fixed size buffer allocation which doubles
the speed on OSX-x64, and a 50% speedup on Linux-x64

I did some benchmarks and CPU profiles and I was looking for where a lot of time was spent, and more time than I would have expected was spent in encodeVarint, and the profiler showed the huge majority of that was allocating a byte slice for it.

I wrote a benchmark and then changed it to use a byte array, the speedups looked like:
```
// OSX-x64 before buffer change
BenchmarkEncodeVarint    20000000            62.6 ns/op
// OSX-x64 after buffer change
BenchmarkEncodeVarint    50000000            33.9 ns/op

// Linux-x64 before buffer change
BenchmarkEncodeVarint    20000000            99.2 ns/op
// Linux-x64 after  buffer change
BenchmarkEncodeVarint    20000000            63.7 ns/op
```
So not bad, 2x speedup on host machine and 1.5x on linux machine... at least for x86-64 this seems a win. Out of curiosity, I also made a 32-bit variant to see if it would be any faster... and it was only about 5% faster on my OSX host so I was about to throw it way, except I went back to my linux VM, and sure enough, linux saw a noticeable speedup:
```
// Linux, x64
BenchmarkEncodeVarint32    50000000	        36.7 ns/op
BenchmarkEncodeVarint64    20000000	        65.8 ns/op
BenchmarkEncodeVarint      20000000         99.2 ns/op
```

Given that 32-bit ints used to go through the same mechanism , that means that encoding a 32-bit int is now almost 3x as fast as it used to be on Linux.. so I'm keeping the 32-bit variant as well.