### PR TITLE
Remove Tell() from the Encoder interface

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -1,8 +1,8 @@
 package avro
 
 import (
-	"bytes"
 	"encoding/binary"
+	"io"
 	"math"
 )
 
@@ -51,27 +51,21 @@ type Encoder interface {
 
 	// Writes raw bytes to this Encoder.
 	WriteRaw([]byte)
-
-	Tell() int64
 }
 
 // BinaryEncoder implements Encoder and provides low-level support for serializing Avro values.
 type BinaryEncoder struct {
-	buffer *bytes.Buffer
+	buffer io.Writer
 }
 
-// Creates a new BinaryEncoder that will write to a given buffer.
-func NewBinaryEncoder(buffer *bytes.Buffer) *BinaryEncoder {
+// Creates a new BinaryEncoder that will write to a given io.Writer.
+func NewBinaryEncoder(buffer io.Writer) *BinaryEncoder {
 	return &BinaryEncoder{buffer: buffer}
 }
 
 // Writes a null value. Doesn't actually do anything in this implementation.
 func (this *BinaryEncoder) WriteNull(_ interface{}) {
 	//do nothing
-}
-
-func (this *BinaryEncoder) Tell() int64 {
-	return int64(this.buffer.Len())
 }
 
 // Writes a boolean value.


### PR DESCRIPTION
This allows NewBinaryEncoder to take an io.Writer, which allows you to
satisfy it with `*bytes.Buffer` or any of a number of things,
including net.Conn and io.Pipe.

While this is technically a breaking change, I suspect nobody actually is writing their own code which relies on calling into Encoder (and if they wrote their own encoder type, they probably are only doing so to pass it into a DatumWriter, therefore whether or not they implement Tell shouldn't matter.)

See #48 for more API updates I'd like to do to put into a "1.0" release of this library