### PR TITLE
Add array out-of-bounds checks when decoding Longs and Ints

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -114,10 +114,17 @@ func (this *BinaryDecoder) ReadInt() (int32, error) {
 	var value uint32
 	var b uint8
 	var offset int
+	bufLen := int64(len(this.buf))
+
 	for {
 		if offset == max_int_buf_size {
 			return 0, IntOverflow
 		}
+
+		if this.pos >= bufLen {
+			return 0, InvalidInt
+		}
+
 		b = this.buf[this.pos]
 		value |= uint32(b&0x7F) << uint(7*offset)
 		this.pos++
@@ -134,14 +141,22 @@ func (this *BinaryDecoder) ReadLong() (int64, error) {
 	var value uint64
 	var b uint8
 	var offset int
+	bufLen := int64(len(this.buf))
+
 	for {
 		if offset == max_long_buf_size {
 			return 0, LongOverflow
 		}
+
+		if this.pos >= bufLen {
+			return 0, InvalidLong
+		}
+
 		b = this.buf[this.pos]
 		value |= uint64(b&0x7F) << uint(7*offset)
 		this.pos++
 		offset++
+
 		if b&0x80 == 0 {
 			break
 		}

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,12 @@ var NegativeBytesLength = errors.New("Negative bytes length")
 // Happens when given value to decode as bool is neither 0x00 nor 0x01.
 var InvalidBool = errors.New("Invalid bool value")
 
+// Happens when given value to decode as a int is invalid
+var InvalidInt = errors.New("Invalid int value")
+
+// Happens when given value to decode as a long is invalid
+var InvalidLong = errors.New("Invalid long value")
+
 // Happens when given value to decode as string has either negative or undecodable length.
 var InvalidStringLength = errors.New("Invalid string length")
 


### PR DESCRIPTION
This fixes a index-out-of-bounds panic in the Avro decoder that can happen if one tries to decode a corrupt object or (I guess) using the wrong schema. This happened to us when reading data from a Kafka topic.