### PR TITLE
Avoids runtime panic out of bounds error when decoding unionised enums

### DIFF
--- a/datum_reader.go
+++ b/datum_reader.go
@@ -490,8 +490,12 @@ func (this *GenericDatumReader) mapUnion(field Schema, dec Decoder) (interface{}
 	if unionType, err := dec.ReadInt(); err != nil {
 		return nil, err
 	} else {
-		union := field.(*UnionSchema).Types[unionType]
-		return this.readValue(union, dec)
+		if unionType >= 0 && unionType < int32(len(field.(*UnionSchema).Types)) {
+			union := field.(*UnionSchema).Types[unionType]
+			return this.readValue(union, dec)
+		} else {
+			return nil, errors.New("Union type overflow")
+		}
 	}
 }
 


### PR DESCRIPTION
When decoding unionised enumerable types, datum reader can encounter the following overflow: -

```
2015/12/08 14:48:02 http: panic serving 127.0.0.1:59482: runtime error: index out of range
goroutine 41 [running]:
net/http.(*conn).serve.func1(0xc8200dc0b0, 0xe64bc0, 0xc82002c1c0)
	/usr/local/Cellar/go/1.5.1/libexec/src/net/http/server.go:1287 +0xb5
github.com/stealthly/go-avro.(*GenericDatumReader).mapUnion(0xc82005b8b8, 0xea0280, 0xc8201873c0, 0xea03c0, 0xc8201875c0, 0x0, 0x0, 0x0, 0x0)
```